### PR TITLE
商品一覧画面の調整

### DIFF
--- a/app/views/goods/index.html.erb
+++ b/app/views/goods/index.html.erb
@@ -125,10 +125,8 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
-
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% @goods.each do |good| %>
       <li class='list'>
-        <% @goods.each do |good| %>
         <%= link_to good_path(good) do %>
         <div class='item-img-content'>
           <%= image_tag good.image.variant(resize:'500x500'), class: "item-img" %>
@@ -155,9 +153,8 @@
           </div>
         </div>
         <% end %>
-        <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% end %>
 
       <%# 商品がない場合のダミー %>
       <%# 商品がある場合は表示されないようにしましょう %>


### PR DESCRIPTION
# what
商品の一覧を表示する。

# why
購入したい商品を探すため。フリマアプリを利用してもらうための入り口。

# キャプチャ画面
商品一覧：https://gyazo.com/a717997d191167ec4b10d5009bf456c3
DBの保存状況：https://gyazo.com/a6690d6c7f8ea8cb2915c832e0215549

先にDB関係の実装から行った結果、変更点がほとんどなかったです。
レビューをよろしくお願いします。