### PR TITLE
商品詳細機能の差分抽出

### DIFF
--- a/app/controllers/goods_controller.rb
+++ b/app/controllers/goods_controller.rb
@@ -1,5 +1,5 @@
 class GoodsController < ApplicationController
-  before_action :move_to_login, except: [:index, :show]
+#  before_action :move_to_login, except: [:index, :show]
 
   def index
     @goods = Good.all.order('created_at DESC')
@@ -26,9 +26,9 @@ class GoodsController < ApplicationController
     render json: { post: { profit: profit.to_i, sales_fee: sales_fee.to_i } }
   end
 
-  def show
-    @good = Good.find(params[:id])
-  end
+  # def show
+  #   @good = Good.find(params[:id])
+  # end
 
   private
 

--- a/app/controllers/goods_controller.rb
+++ b/app/controllers/goods_controller.rb
@@ -1,5 +1,5 @@
 class GoodsController < ApplicationController
-#  before_action :move_to_login, except: [:index, :show]
+  before_action :move_to_login, except: [:index, :show]
 
   def index
     @goods = Good.all.order('created_at DESC')
@@ -26,9 +26,9 @@ class GoodsController < ApplicationController
     render json: { post: { profit: profit.to_i, sales_fee: sales_fee.to_i } }
   end
 
-  # def show
-  #   @good = Good.find(params[:id])
-  # end
+  def show
+    @good = Good.find(params[:id])
+  end
 
   private
 

--- a/app/views/goods/show.html.erb
+++ b/app/views/goods/show.html.erb
@@ -4,7 +4,7 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= "【商品名】#{@good.name}" %>
     </h2>
     <div class='item-img-content'>
       <%= image_tag @good.image.variant(resize:'500x500') ,class:"item-box-img" %>
@@ -26,48 +26,46 @@
     </div>
 
     <%# ログインしているユーザと出品しているユーザが同一人物である時、商品の編集と削除を表示にしましょう%>
-    <%# if current_user == @good.user %>
+    <% if current_user == @good.user %>
     <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
     <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
-    <%# elsif  %>
-
     <%# 商品が売れていない場合はこちらを表示しましょう %>
+    <% elsif @good.buy_history == nil %>
     <%= link_to '購入画面に進む', good_buys_path(@good) ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
-    <%# end %>
+    <% end %>
 
     <%# // ログインしているユーザと出品しているユーザが同一人物である時、商品の編集と削除を表示にしましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= "【商品説明】#{@good.description}" %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @good.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= Category.find(@good.category_id).name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= GoodStatus.find(@good.status_id).name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= FeeCharger.find(@good.fee_charger_id).name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= Prefecture.find(@good.origin_prefecture_id).name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= DeliveryDay.find(@good.delivery_days_id).name %></td>
         </tr>
       </tbody>
     </table>
@@ -106,7 +104,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <a href="#" class='another-item'><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class='another-item'><%= Category.find(@good.category_id).name %>カテゴリーの商品をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/goods/show.html.erb
+++ b/app/views/goods/show.html.erb
@@ -4,7 +4,7 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "【商品名】#{@good.name}" %>
+      <%= "商品名" %>
     </h2>
     <div class='item-img-content'>
       <%= image_tag @good.image.variant(resize:'500x500') ,class:"item-box-img" %>
@@ -26,46 +26,48 @@
     </div>
 
     <%# ログインしているユーザと出品しているユーザが同一人物である時、商品の編集と削除を表示にしましょう%>
-    <% if current_user == @good.user %>
+    <%# if current_user == @good.user %>
     <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
     <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+
+    <%# elsif  %>
+
     <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <% elsif @good.buy_history == nil %>
     <%= link_to '購入画面に進む', good_buys_path(@good) ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
-    <% end %>
+    <%# end %>
 
     <%# // ログインしているユーザと出品しているユーザが同一人物である時、商品の編集と削除を表示にしましょう %>
 
     <div class="item-explain-box">
-      <span><%= "【商品説明】#{@good.description}" %></span>
+      <span><%= "商品説明" %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= @good.user.nickname %></td>
+          <td class="detail-value"><%= "出品者名" %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= Category.find(@good.category_id).name %></td>
+          <td class="detail-value"><%= "カテゴリー名" %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= GoodStatus.find(@good.status_id).name %></td>
+          <td class="detail-value"><%= "商品の状態" %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= FeeCharger.find(@good.fee_charger_id).name %></td>
+          <td class="detail-value"><%= "発送料の負担" %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= Prefecture.find(@good.origin_prefecture_id).name %></td>
+          <td class="detail-value"><%= "発送元の地域" %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= DeliveryDay.find(@good.delivery_days_id).name %></td>
+          <td class="detail-value"><%= "発送日の目安" %></td>
         </tr>
       </tbody>
     </table>
@@ -104,7 +106,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <a href="#" class='another-item'><%= Category.find(@good.category_id).name %>カテゴリーの商品をもっと見る</a>
+  <a href="#" class='another-item'><%= "商品のカテゴリー名" %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/goods/show.html.erb
+++ b/app/views/goods/show.html.erb
@@ -4,16 +4,16 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "【商品名】#{@good.name}" %>
+      <%#= "【商品名】#{@good.name}" %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag @good.image.variant(resize:'500x500') ,class:"item-box-img" %>
+      <%#= image_tag @good.image.variant(resize:'500x500') ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outの表示をしましょう。 %>
-      <% if @good.buy_history != nil %>
+      <%# if @good.buy_history != nil %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
       </div>
-      <% end %>
+      <%# end %>
       <%# //商品が売れている場合は、sold outの表示をしましょう。 %>
     </div>
     <div class="item-price-box">
@@ -26,15 +26,15 @@
     </div>
 
     <%# ログインしているユーザと出品しているユーザが同一人物である時、商品の編集と削除を表示にしましょう%>
-    <% if current_user == @good.user %>
+    <%# if current_user == @good.user && @good.buy_history == nil %>
     <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
     <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <% elsif @good.buy_history == nil %>
-    <%= link_to '購入画面に進む', good_buys_path(@good) ,class:"item-red-btn"%>
+    <%#= link_to '購入画面に進む', good_buys_path(@good) ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
-    <% end %>
+    <%# end %>
 
     <%# // ログインしているユーザと出品しているユーザが同一人物である時、商品の編集と削除を表示にしましょう %>
 
@@ -45,27 +45,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= @good.user.nickname %></td>
+          <td class="detail-value"><%#= @good.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= Category.find(@good.category_id).name %></td>
+          <td class="detail-value"><%#= Category.find(@good.category_id).name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= GoodStatus.find(@good.status_id).name %></td>
+          <td class="detail-value"><%#= GoodStatus.find(@good.status_id).name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= FeeCharger.find(@good.fee_charger_id).name %></td>
+          <td class="detail-value"><%#= FeeCharger.find(@good.fee_charger_id).name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= Prefecture.find(@good.origin_prefecture_id).name %></td>
+          <td class="detail-value"><%#= Prefecture.find(@good.origin_prefecture_id).name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= DeliveryDay.find(@good.delivery_days_id).name %></td>
+          <td class="detail-value"><%#= DeliveryDay.find(@good.delivery_days_id).name %></td>
         </tr>
       </tbody>
     </table>
@@ -104,7 +104,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <a href="#" class='another-item'><%= Category.find(@good.category_id).name %>カテゴリーの商品をもっと見る</a>
+  <a href="#" class='another-item'><%#= Category.find(@good.category_id).name %>カテゴリーの商品をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/goods/show.html.erb
+++ b/app/views/goods/show.html.erb
@@ -8,13 +8,11 @@
     </h2>
     <div class='item-img-content'>
       <%= image_tag @good.image.variant(resize:'500x500') ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outの表示をしましょう。 %>
       <% if @good.buy_history != nil %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
       </div>
       <% end %>
-      <%# //商品が売れている場合は、sold outの表示をしましょう。 %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
@@ -25,18 +23,13 @@
       </span>
     </div>
 
-    <%# ログインしているユーザと出品しているユーザが同一人物である時、商品の編集と削除を表示にしましょう%>
     <% if current_user == @good.user && @good.buy_history == nil %>
     <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
     <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
     <% elsif @good.buy_history == nil %>
     <%= link_to '購入画面に進む', good_buys_path(@good) ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
     <% end %>
-
-    <%# // ログインしているユーザと出品しているユーザが同一人物である時、商品の編集と削除を表示にしましょう %>
 
     <div class="item-explain-box">
       <span><%= "【商品説明】#{@good.description}" %></span>

--- a/app/views/goods/show.html.erb
+++ b/app/views/goods/show.html.erb
@@ -4,16 +4,16 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%#= "【商品名】#{@good.name}" %>
+      <%= "【商品名】#{@good.name}" %>
     </h2>
     <div class='item-img-content'>
-      <%#= image_tag @good.image.variant(resize:'500x500') ,class:"item-box-img" %>
+      <%= image_tag @good.image.variant(resize:'500x500') ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outの表示をしましょう。 %>
-      <%# if @good.buy_history != nil %>
+      <% if @good.buy_history != nil %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
       </div>
-      <%# end %>
+      <% end %>
       <%# //商品が売れている場合は、sold outの表示をしましょう。 %>
     </div>
     <div class="item-price-box">
@@ -26,15 +26,15 @@
     </div>
 
     <%# ログインしているユーザと出品しているユーザが同一人物である時、商品の編集と削除を表示にしましょう%>
-    <%# if current_user == @good.user && @good.buy_history == nil %>
+    <% if current_user == @good.user && @good.buy_history == nil %>
     <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
     <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <% elsif @good.buy_history == nil %>
-    <%#= link_to '購入画面に進む', good_buys_path(@good) ,class:"item-red-btn"%>
+    <%= link_to '購入画面に進む', good_buys_path(@good) ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
-    <%# end %>
+    <% end %>
 
     <%# // ログインしているユーザと出品しているユーザが同一人物である時、商品の編集と削除を表示にしましょう %>
 
@@ -45,27 +45,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%#= @good.user.nickname %></td>
+          <td class="detail-value"><%= @good.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%#= Category.find(@good.category_id).name %></td>
+          <td class="detail-value"><%= Category.find(@good.category_id).name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%#= GoodStatus.find(@good.status_id).name %></td>
+          <td class="detail-value"><%= GoodStatus.find(@good.status_id).name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%#= FeeCharger.find(@good.fee_charger_id).name %></td>
+          <td class="detail-value"><%= FeeCharger.find(@good.fee_charger_id).name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%#= Prefecture.find(@good.origin_prefecture_id).name %></td>
+          <td class="detail-value"><%= Prefecture.find(@good.origin_prefecture_id).name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%#= DeliveryDay.find(@good.delivery_days_id).name %></td>
+          <td class="detail-value"><%= DeliveryDay.find(@good.delivery_days_id).name %></td>
         </tr>
       </tbody>
     </table>
@@ -104,7 +104,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <a href="#" class='another-item'><%#= Category.find(@good.category_id).name %>カテゴリーの商品をもっと見る</a>
+  <a href="#" class='another-item'><%= Category.find(@good.category_id).name %>カテゴリーの商品をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
-  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   root "goods#index"
   resources :goods, only: [:index, :new, :create, :show] do
     resources :buys, only: [:index, :create]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   root "goods#index"
-#  resources :goods, only: [:index, :new, :create, :show] do
+  resources :goods, only: [:index, :new, :create, :show] do
     resources :buys, only: [:index, :create]
     collection do
       get 'profit_calc'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   root "goods#index"
-  resources :goods, only: [:index, :new, :create, :show] do
+#  resources :goods, only: [:index, :new, :create, :show] do
     resources :buys, only: [:index, :create]
     collection do
       get 'profit_calc'


### PR DESCRIPTION
# what
商品の詳細表示機能の実装

# why
商品の情報を詳しく見た上で購入の判定をしてもらうため。（マッチングの満足度をあげるため）

# キャプチャ画像(全体を表示するため、25%に縮小して表示しています)
出品者による閲覧：https://gyazo.com/ff2b4e327f449f5c3870fafe00e860a4
詳細情報の部分：https://gyazo.com/380762a09bed5f0f5f6ae74f19daa9df
その他のユーザによる閲覧：https://gyazo.com/deaf471f59de395121b3143eb4bae0a4
未ログインユーザによる閲覧（商品購入画面に進めるようにしてあります）：https://gyazo.com/ab4410d0bacd0597be09c2a2428cd9da
購入済み商品の閲覧：https://gyazo.com/e086c617a342d1063c7f08ee3a6a01b2

# 実装状況
画面遷移図：https://gyazo.com/63997b6cd5e775676382b461effd738d

# これまでの経緯
商品購入機能を先に実装してしまったため、既にルーティング設定が完了していた。
以下文面をもとにコネクトメンターに相談したところ、
> こちらのプルリクエストですが、file changesの差分があがっていないため、コードレビューをすることができません。
> このような場合、一度コネクトメンターにどうしたらいいか、相談してみましょう。
> 修正点の差分を反映することができましたら、再度プルリクエストの提出をお願いいたします。
商品詳細のブランチで差分をコメントアウトし、さらにブランチを切ったところ(商品詳細機能の差分抽出)でプルリクエストを出すことで、revertによるミスが防がれるとのことで、その案が最適であると判断しました。

以前のコードレビューは以下のリンクより閲覧できます。
#9 詳細表示機能

コードレビューよろしくお願いします。