### PR TITLE
エラーメッセージの日本語化

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,3 +74,5 @@ gem 'image_processing', '~>1.2'
 gem 'payjp'
 
 gem 'aws-sdk-s3', require: false
+
+gem 'rails-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -192,6 +192,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails-i18n (6.0.0)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 7)
     rails_12factor (0.0.3)
       rails_serve_static_assets
       rails_stdout_logging
@@ -334,6 +337,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rails (~> 6.0.0)
+  rails-i18n
   rails_12factor
   rspec-rails
   rubocop

--- a/app/forms/buy_info.rb
+++ b/app/forms/buy_info.rb
@@ -8,11 +8,11 @@ class BuyInfo
 
   # バリデーション（BuyerとBuyHistoryモデル）
   with_options presence: true do
-    validates :postal_code, format: { with: /\A\d{3}[-]\d{4}\z/ }
-    validates :addr_prefecture_id, numericality: { other_than: 1 }
+    validates :postal_code, format: { with: /\A\d{3}[-]\d{4}\z/, allow_blank: true }
+    validates :addr_prefecture_id, numericality: { other_than: 1, allow_blank: true }
     validates :addr_municipality
     validates :addr_house_number
-    validates :tel_number, length: { maximum: 11 }, numericality: true
+    validates :tel_number, length: { maximum: 11, allow_blank: true }, numericality: { allow_blank: true }
     validates :user
     validates :good
   end

--- a/app/models/good.rb
+++ b/app/models/good.rb
@@ -1,13 +1,13 @@
 class Good < ApplicationRecord
   # バリデーション
   with_options presence: true do
-    validates :name,                 length: { maximum: 40 }
-    validates :description,          length: { maximum: 1000 }
+    validates :name,                 length: { maximum: 40, allow_blank: true }
+    validates :description,          length: { maximum: 1000, allow_blank: true }
     validates :price,                numericality: {
-                                      only_integer: true, greater_than_or_equal_to: 300, less_than: 10_000_000
+                                      only_integer: true, greater_than_or_equal_to: 300, less_than: 10_000_000, allow_blank: true
                                      }
     validates :images
-    with_options numericality: { other_than: 1 } do
+    with_options numericality: { other_than: 1, allow_blank: true } do
       validates :category_id
       validates :status_id
       validates :origin_prefecture_id

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,16 +3,21 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
-
-  validates :nickname,         presence: true
-  # uniquenessについて、Rails6.1にする場合、読んで欲しい、https://qiita.com/jnchito/items/e23b1facc72bd86234b6
-  validates :email,            presence: true, uniqueness: { case_sensitive: true }
-  validates :password,         presence: true, format: { with: /\A(?=.*?[a-zA-Z])(?=.*?\d)[a-zA-Z\d]{6,}\z/ }  # UTF-8の全角文字の範囲調べる
-  validates :given_name,       presence: true, format: { with: /\A[ぁ-んァ-ン一-龥]+\z/ }
-  validates :family_name,      presence: true, format: { with: /\A[ぁ-んァ-ン一-龥]+\z/ }
-  validates :given_name_kana,  presence: true, format: { with: /\A[ァ-ン]+\z/ }
-  validates :family_name_kana, presence: true, format: { with: /\A[ァ-ン]+\z/ }
-  validates :birth_day,        presence: true
+  with_options presence: true do
+    validates :nickname
+    # uniquenessについて、Rails6.1にする場合、読んで欲しい、https://qiita.com/jnchito/items/e23b1facc72bd86234b6
+    validates :email,            uniqueness: { case_sensitive: true, allow_blank: true }
+    validates :password,         format: { with: /\A(?=.*?[a-zA-Z])(?=.*?\d)[a-zA-Z\d]{6,}\z/, allow_blank: true }
+    with_options format: { with: /\A[ぁ-んァ-ン一-龥]+\z/, allow_blank: true } do
+      validates :given_name
+      validates :family_name
+    end
+    with_options format: { with: /\A[ァ-ン]+\z/, allow_blank: true } do
+      validates :given_name_kana
+      validates :family_name_kana
+    end
+    validates :birth_day
+  end
 
   has_many :goods
   has_many :buy_histories

--- a/app/views/goods/index.html.erb
+++ b/app/views/goods/index.html.erb
@@ -129,7 +129,7 @@
       <li class='list'>
         <%= link_to good_path(good) do %>
         <div class='item-img-content'>
-          <%= image_tag good.images[0], class: "item-img" %>
+          <%= image_tag good.images[0].variant(resize:'500x500'), class: "item-img" %>
 
           <%# 商品が売れていればsold outの表示 %>
           <% if good.buy_history != nil %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,8 @@ module Furima29218
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
 
+    # 日本語の言語設定
+    config.i18n.default_locale = :ja 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,143 @@
+  
+ja:
+  activerecord:
+    attributes:
+      user:
+        confirmation_sent_at: パスワード確認送信時刻
+        confirmation_token: パスワード確認用トークン
+        confirmed_at: パスワード確認時刻
+        created_at: 作成日
+        current_password: 現在のパスワード
+        current_sign_in_at: 現在のログイン時刻
+        current_sign_in_ip: 現在のログインIPアドレス
+        email: メールアドレス
+        encrypted_password: 暗号化パスワード
+        failed_attempts: 失敗したログイン試行回数
+        last_sign_in_at: 最終ログイン時刻
+        last_sign_in_ip: 最終ログインIPアドレス
+        locked_at: ロック時刻
+        password: パスワード
+        password_confirmation: パスワード（確認）
+        remember_created_at: ログイン記憶時刻
+        remember_me: ログインを記憶する
+        reset_password_sent_at: パスワードリセット送信時刻
+        reset_password_token: パスワードリセット用トークン
+        sign_in_count: ログイン回数
+        unconfirmed_email: 未確認Eメール
+        unlock_token: ロック解除用トークン
+        updated_at: 更新日
+    models:
+      user: ユーザ
+  devise:
+    confirmations:
+      confirmed: メールアドレスが確認できました。
+      new:
+        resend_confirmation_instructions: アカウント確認メール再送
+      send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
+    failure:
+      already_authenticated: すでにログインしています。
+      inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
+      invalid: "%{authentication_keys}またはパスワードが違います。"
+      last_attempt: もう一回誤るとアカウントがロックされます。
+      locked: アカウントは凍結されています。
+      not_found_in_database: "%{authentication_keys}またはパスワードが違います。"
+      timeout: セッションがタイムアウトしました。もう一度ログインしてください。
+      unauthenticated: アカウント登録もしくはログインしてください。
+      unconfirmed: メールアドレスの本人確認が必要です。
+    mailer:
+      confirmation_instructions:
+        action: メールアドレスの確認
+        greeting: "%{recipient}様"
+        instruction: 以下のリンクをクリックし、メールアドレスの確認手続を完了させてください。
+        subject: メールアドレス確認メール
+      email_changed:
+        greeting: こんにちは、%{recipient}様。
+        message: あなたのメール変更（%{email}）のお知らせいたします。
+        subject: メール変更完了。
+      password_change:
+        greeting: "%{recipient}様"
+        message: パスワードが再設定されたことを通知します。
+        subject: パスワードの変更について
+      reset_password_instructions:
+        action: パスワード変更
+        greeting: "%{recipient}様"
+        instruction: パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。
+        instruction_2: パスワード再設定の依頼をしていない場合、このメールを無視してください。
+        instruction_3: パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません。
+        subject: パスワードの再設定について
+      unlock_instructions:
+        action: アカウントのロック解除
+        greeting: "%{recipient}様"
+        instruction: アカウントのロックを解除するには下のリンクをクリックしてください。
+        message: ログイン失敗が繰り返されたため、アカウントはロックされています。
+        subject: アカウントの凍結解除について
+    omniauth_callbacks:
+      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+      success: "%{kind} アカウントによる認証に成功しました。"
+    passwords:
+      edit:
+        change_my_password: パスワードを変更する
+        change_your_password: パスワードを変更
+        confirm_new_password: 確認用新しいパスワード
+        new_password: 新しいパスワード
+      new:
+        forgot_your_password: パスワードを忘れましたか?
+        send_me_reset_password_instructions: パスワードの再設定方法を送信する
+      no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
+      send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。
+      updated: パスワードが正しく変更されました。
+      updated_not_active: パスワードが正しく変更されました。
+    registrations:
+      destroyed: アカウントを削除しました。またのご利用をお待ちしております。
+      edit:
+        are_you_sure: 本当によろしいですか?
+        cancel_my_account: アカウント削除
+        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
+        leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
+        title: "%{resource}編集"
+        unhappy: 気に入りません
+        update: 更新
+        we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
+      new:
+        sign_up: アカウント登録
+      signed_up: アカウント登録が完了しました。
+      signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
+      signed_up_but_locked: アカウントが凍結されているためログインできません。
+      signed_up_but_unconfirmed: 本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。
+      update_needs_confirmation: アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。
+      updated: アカウント情報を変更しました。
+      updated_but_not_signed_in: あなたのアカウントは正常に更新されましたが、パスワードが変更されたため、再度ログインしてください。
+    sessions:
+      already_signed_out: 既にログアウト済みです。
+      new:
+        sign_in: ログイン
+      signed_in: ログインしました。
+      signed_out: ログアウトしました。
+    shared:
+      links:
+        back: 戻る
+        didn_t_receive_confirmation_instructions: アカウント確認のメールを受け取っていませんか?
+        didn_t_receive_unlock_instructions: アカウントの凍結解除方法のメールを受け取っていませんか?
+        forgot_your_password: パスワードを忘れましたか?
+        sign_in: ログイン
+        sign_in_with_provider: "%{provider}でログイン"
+        sign_up: アカウント登録
+      minimum_password_length: "（%{count}字以上）"
+    unlocks:
+      new:
+        resend_unlock_instructions: アカウントの凍結解除方法を再送する
+      send_instructions: アカウントの凍結解除方法を数分以内にメールでご連絡します。
+      send_paranoid_instructions: アカウントが見つかった場合、アカウントの凍結解除方法を数分以内にメールでご連絡します。
+      unlocked: アカウントを凍結解除しました。
+  errors:
+    messages:
+      already_confirmed: は既に登録済みです。ログインしてください。
+      confirmation_period_expired: の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。
+      expired: の有効期限が切れました。新しくリクエストしてください。
+      not_found: は見つかりませんでした。
+      not_locked: は凍結されていません。
+      not_saved:
+        one: エラーが発生したため %{resource} は保存されませんでした。
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,41 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        nickname: ニックネーム
+        given_name: 名前(全角)
+        family_name: 苗字(全角)
+        given_name_kana: 名前(カナ)
+        family_name_kana: 苗字(カナ)
+        birth_day: 生年月日
+      good:
+        name: 商品名
+        images: 出品画像
+        description: 商品の説明
+        category_id: 商品のカテゴリー
+        status_id: 商品の状態
+        fee_charger_id: 配送料の負担者
+        origin_prefecture_id: 発送元の地域
+        delivery_days_id: 発送までの日数
+        price: 販売価格
+  activemodel:
+    attributes:
+      buy_info:
+        postal_code: 郵便番号
+        addr_prefecture_id: 都道府県
+        addr_municipality: 市区町村
+        addr_house_number: 番地
+        tel_number: 電話番号
+      credit:
+        token: クレジットカード情報
+  errors:
+    messages:
+      other_than: を選択してください
+      invalid: の入力を確認してください
+      not_a_number: に半角数字のみで記入してください
+
+
+
+
+ 
+        

--- a/spec/models/buy_info_spec.rb
+++ b/spec/models/buy_info_spec.rb
@@ -20,25 +20,25 @@ RSpec.describe 'BuyInfoモデル', type: :model do
       it '空だと登録できない' do
         @buy_info.postal_code = nil
         @buy_info.valid?
-        expect(@buy_info.errors.full_messages).to include("Postal code can't be blank")
+        expect(@buy_info.errors.full_messages).to include("郵便番号を入力してください")
       end
       it '数字の桁数が違うと登録できない' do
         @buy_info.postal_code = "#{Faker::Number.number(digits: 2)}-#{Faker::Number.number(digits: 4)}"
         @buy_info.valid?
-        expect(@buy_info.errors.full_messages).to include('Postal code is invalid')
+        expect(@buy_info.errors.full_messages).to include("郵便番号の入力を確認してください")
         @buy_info.postal_code = "#{Faker::Number.number(digits: 3)}-#{Faker::Number.number(digits: 5)}"
         @buy_info.valid?
-        expect(@buy_info.errors.full_messages).to include('Postal code is invalid')
+        expect(@buy_info.errors.full_messages).to include("郵便番号の入力を確認してください")
       end
       it 'ハイフンがないと登録できない' do
         @buy_info.postal_code = "#{Faker::Number.number(digits: 3)}#{Faker::Number.number(digits: 4)}"
         @buy_info.valid?
-        expect(@buy_info.errors.full_messages).to include('Postal code is invalid')
+        expect(@buy_info.errors.full_messages).to include("郵便番号の入力を確認してください")
       end
       it '数字以外があると登録できない' do
         @buy_info.postal_code = Faker::Lorem.paragraph_by_chars(number: 8)
         @buy_info.valid?
-        expect(@buy_info.errors.full_messages).to include('Postal code is invalid')
+        expect(@buy_info.errors.full_messages).to include("郵便番号の入力を確認してください")
       end
     end
     # address(prefecture)
@@ -46,7 +46,7 @@ RSpec.describe 'BuyInfoモデル', type: :model do
       it 'id が 1 だと登録できない' do
         @buy_info.addr_prefecture_id = Prefecture.first.id
         @buy_info.valid?
-        expect(@buy_info.errors.full_messages).to include('Addr prefecture must be other than 1')
+        expect(@buy_info.errors.full_messages).to include("都道府県を選択してください")
       end
     end
     # address(municipality)
@@ -54,7 +54,7 @@ RSpec.describe 'BuyInfoモデル', type: :model do
       it '空だと登録できない' do
         @buy_info.addr_municipality = nil
         @buy_info.valid?
-        expect(@buy_info.errors.full_messages).to include("Addr municipality can't be blank")
+        expect(@buy_info.errors.full_messages).to include("市区町村を入力してください")
       end
     end
     # address(house_number)
@@ -62,7 +62,7 @@ RSpec.describe 'BuyInfoモデル', type: :model do
       it '空だと登録できない' do
         @buy_info.addr_house_number = nil
         @buy_info.valid?
-        expect(@buy_info.errors.full_messages).to include("Addr house number can't be blank")
+        expect(@buy_info.errors.full_messages).to include("番地を入力してください")
       end
     end
     # address(building)はなし
@@ -71,17 +71,17 @@ RSpec.describe 'BuyInfoモデル', type: :model do
       it '空だと登録できない' do
         @buy_info.tel_number = nil
         @buy_info.valid?
-        expect(@buy_info.errors.full_messages).to include("Tel number can't be blank")
+        expect(@buy_info.errors.full_messages).to include("電話番号を入力してください")
       end
       it '12桁以上だと登録できない' do
         @buy_info.tel_number = Faker::Number.number(digits: 12)
         @buy_info.valid?
-        expect(@buy_info.errors.full_messages).to include('Tel number is too long (maximum is 11 characters)')
+        expect(@buy_info.errors.full_messages).to include("電話番号は11文字以内で入力してください")
       end
       it '数字以外が入っていると登録できない' do
-        @buy_info.tel_number = Faker::Lorem.characters(number: 11)
+        @buy_info.tel_number = Faker::Alphanumeric.alphanumeric(number: 11, min_alpha: 1)
         @buy_info.valid?
-        expect(@buy_info.errors.full_messages).to include('Tel number is not a number')
+        expect(@buy_info.errors.full_messages).to include("電話番号に半角数字のみで記入してください")
       end
     end
     # user_id
@@ -89,7 +89,7 @@ RSpec.describe 'BuyInfoモデル', type: :model do
       it 'user_idがないと登録できない' do
         @buy_info.user = nil
         @buy_info.valid?
-        expect(@buy_info.errors.full_messages).to include("User can't be blank")
+        expect(@buy_info.errors.full_messages).to include("Userを入力してください")
       end
     end
     # good_id
@@ -97,7 +97,7 @@ RSpec.describe 'BuyInfoモデル', type: :model do
       it 'good_idないと登録できない' do
         @buy_info.good = nil
         @buy_info.valid?
-        expect(@buy_info.errors.full_messages).to include("Good can't be blank")
+        expect(@buy_info.errors.full_messages).to include("Goodを入力してください")
       end
     end
   end

--- a/spec/models/good_spec.rb
+++ b/spec/models/good_spec.rb
@@ -5,112 +5,121 @@ RSpec.describe Good, type: :model do
     @good = FactoryBot.build(:good)
   end
   describe '商品情報の保存の可否' do
-    # name
-    it 'nameが空だと登録できない' do
-      @good.name = nil
-      @good.valid?
-      expect(@good.errors.full_messages).to include("Name can't be blank")
+    context '商品名(name)を登録できないとき' do
+      it '空だと登録できない' do
+        @good.name = nil
+        @good.valid?
+        expect(@good.errors.full_messages).to include("商品名を入力してください")
+      end
+      it '41文字以上だと登録できない' do
+        @good.name = Faker::Lorem.paragraph_by_chars(number: 41)
+        @good.valid?
+        expect(@good.errors.full_messages).to include("商品名は40文字以内で入力してください")
+      end
     end
-    it 'nameが41文字以上だと登録できない' do
-      @good.name = Faker::Lorem.paragraph_by_chars(number: 41)
-      @good.valid?
-      expect(@good.errors.full_messages).to include('Name is too long (maximum is 40 characters)')
+    context '商品の概要(description)を登録できないとき' do
+      it '空だと登録できない' do
+        @good.description = nil
+        @good.valid?
+        expect(@good.errors.full_messages).to include("商品の説明を入力してください")
+      end
+      it '1001文字以上だと登録できない' do
+        @good.description = Faker::Lorem.paragraph_by_chars(number: 1001)
+        @good.valid?
+        expect(@good.errors.full_messages).to include("商品の説明は1000文字以内で入力してください")
+      end
     end
-    # description
-    it 'descriptionが空だと登録できない' do
-      @good.description = nil
-      @good.valid?
-      expect(@good.errors.full_messages).to include("Description can't be blank")
+    context '商品カテゴリを登録できないとき' do
+      it 'category_idが1だと登録できない' do
+        @good.category_id = Category.first.id
+        @good.valid?
+        expect(@good.errors.full_messages).to include("商品のカテゴリーを選択してください")
+      end
     end
-    it 'descriptionが1001文字以上だと登録できない' do
-      @good.description = Faker::Lorem.paragraph_by_chars(number: 1001)
-      @good.valid?
-      expect(@good.errors.full_messages).to include('Description is too long (maximum is 1000 characters)')
+    context '商品の状態を登録できないとき' do
+      it 'status_idが1だと登録できない' do
+        @good.status_id = GoodStatus.first.id
+        @good.valid?
+        expect(@good.errors.full_messages).to include("商品の状態を選択してください")
+      end
     end
-    # category
-    it 'category_idが1だと登録できない' do
-      @good.category_id = Category.first.id
-      @good.valid?
-      expect(@good.errors.full_messages).to include('Category must be other than 1')
+    context '発送元の地域を登録できないとき' do
+      it 'origin_prefecture_idが1だと登録できない' do
+        @good.origin_prefecture_id = Prefecture.first.id
+        @good.valid?
+        expect(@good.errors.full_messages).to include("発送元の地域を選択してください")
+      end
     end
-    # status
-    it 'status_idが1だと登録できない' do
-      @good.status_id = GoodStatus.first.id
-      @good.valid?
-      expect(@good.errors.full_messages).to include('Status must be other than 1')
+    context '発送までの日数を登録できないとき' do
+      it 'delivery_days_idが1だと登録できない' do
+        @good.delivery_days_id = DeliveryDay.first.id
+        @good.valid?
+        expect(@good.errors.full_messages).to include("発送までの日数を選択してください")
+      end
     end
-    # origin_prefecture
-    it 'origin_prefecture_idが1だと登録できない' do
-      @good.origin_prefecture_id = Prefecture.first.id
-      @good.valid?
-      expect(@good.errors.full_messages).to include('Origin prefecture must be other than 1')
+    context '配送料の負担者を登録できないとき' do
+      it 'fee_charger_idが1だと登録できない' do
+        @good.fee_charger_id = FeeCharger.first.id
+        @good.valid?
+        expect(@good.errors.full_messages).to include("配送料の負担者を選択してください")
+      end
     end
-    # delivery_days
-    it 'delivery_days_idが1だと登録できない' do
-      @good.delivery_days_id = DeliveryDay.first.id
-      @good.valid?
-      expect(@good.errors.full_messages).to include('Delivery days must be other than 1')
+    context 'priceを登録できないとき' do
+      it 'priceが空だと登録できない' do
+        @good.price = nil
+        @good.valid?
+        expect(@good.errors.full_messages).to include("販売価格を入力してください")
+      end
+      it 'priceに数字以外が入ると登録できない' do
+        @good.price = Faker::Alphanumeric.alphanumeric(number: 7, min_alpha: 1)
+        @good.valid?
+        expect(@good.errors.full_messages).to include("販売価格に半角数字のみで記入してください")
+      end
+      it 'priceが整数でない場合、登録できない' do
+        @good.price = Faker::Number.decimal(l_digits: 7, r_digits: 4)
+        @good.valid?
+        expect(@good.errors.full_messages).to include("販売価格は整数で入力してください")
+      end
+      it 'priceが299だと登録できない' do
+        @good.price = 299
+        @good.valid?
+        expect(@good.errors.full_messages).to include("販売価格は300以上の値にしてください")
+      end
+      it 'priceが10,000,000だと登録できない' do
+        @good.price = 10_000_000
+        @good.valid?
+        expect(@good.errors.full_messages).to include("販売価格は10000000より小さい値にしてください")
+      end
     end
-    # fee_charger
-    it 'fee_charger_idが1だと登録できない' do
-      @good.fee_charger_id = FeeCharger.first.id
-      @good.valid?
-      expect(@good.errors.full_messages).to include('Fee charger must be other than 1')
+    context 'priceを登録できるとき' do
+      it 'priceが300だと登録できる' do
+        @good.price = 300
+        expect(@good).to be_valid
+      end
+      it 'priceが9,999,999だと登録できる' do
+        @good.price = 9_999_999
+        expect(@good).to be_valid
+      end
     end
-    # price
-    it 'priceが空だと登録できない' do
-      @good.price = nil
-      @good.valid?
-      expect(@good.errors.full_messages).to include("Price can't be blank")
+    context 'user_idを登録できるとき' do
+      it 'userが紐づいていないと登録できない' do
+        @good.user = nil
+        @good.valid?
+        expect(@good.errors.full_messages).to include("Userを入力してください")
+      end
     end
-    it 'priceに数字以外が入ると登録できない' do
-      @good.price = 'sample123'
-      @good.valid?
-      expect(@good.errors.full_messages).to include('Price is not a number')
+    context '出品画像を登録できるとき' do
+      it 'imageが紐づいていないと登録できない' do
+        @good.images = nil
+        @good.valid?
+        expect(@good.errors.full_messages).to include("出品画像を入力してください")
+      end
     end
-    it 'priceが整数でない場合、登録できない' do
-      @good.price = Faker::Number.decimal(l_digits: 7, r_digits: 3)
-      @good.valid?
-      expect(@good.errors.full_messages).to include('Price must be an integer')
-    end
-    it 'priceが299だと登録できない' do
-      @good.price = 299
-      @good.valid?
-      expect(@good.errors.full_messages).to include('Price must be greater than or equal to 300')
-    end
-    it 'priceが300だと登録できる' do
-      @good.price = 300
-      expect(@good).to be_valid
-    end
-    it 'priceが9,999,999だと登録できる' do
-      @good.price = 9_999_999
-      expect(@good).to be_valid
-    end
-    it 'priceが10,000,000だと登録できない' do
-      @good.price = 10_000_000
-      @good.valid?
-      expect(@good.errors.full_messages).to include('Price must be less than 10000000')
-    end
-    # user
-    it 'userが紐づいていないと登録できない' do
-      @good.user = nil
-      @good.valid?
-      expect(@good.errors.full_messages).to include('User must exist')
-    end
-    # image
-    it 'imageが紐づいていないと登録できない' do
-      @good.images = nil
-      @good.valid?
-      expect(@good.errors.full_messages).to include("Images can't be blank")
-    end
-    # 正常
-    it 'すべてのデータがバリデーションの範囲内ならば登録できる' do
-      expect(@good).to be_valid
-      goods = FactoryBot.create_list(:good, 30)
-      goods.each do |good|
-        if !(expect(good).to be_valid)
-          puts good.user
-        end
+    context '登録できるとき' do
+      it 'すべてのデータがバリデーションの範囲内ならば登録できる' do
+        expect(@good).to be_valid
+        goods = FactoryBot.create_list(:good, 30)
+        goods.each { |good| expect(good).to be_valid }
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -5,183 +5,188 @@ RSpec.describe User, type: :model do
     @user = FactoryBot.build(:user)
   end
   describe 'ユーザ登録の可否' do
-    # nickname
-    it 'nicknameが空だと登録できない' do
-      @user.nickname = ''
-      @user.valid?
-      expect(@user.errors.full_messages).to include("Nickname can't be blank")
+    context 'nicknameが登録できないとき' do
+      it '空だと登録できない' do
+        @user.nickname = ''
+        @user.valid?
+        expect(@user.errors.full_messages).to include("ニックネームを入力してください")
+      end
     end
-    # email
-    it 'emailが空だと登録できない' do
-      @user.email = ''
-      @user.valid?
-      expect(@user.errors.full_messages).to include("Email can't be blank")
+    context 'emailが登録できないとき' do
+      it '空だと登録できない' do
+        @user.email = ''
+        @user.valid?
+        expect(@user.errors.full_messages).to include("メールアドレスを入力してください")
+      end
+      it '「@」がないと登録できない' do
+        @user.email = 'sample_sample.com'
+        @user.valid?
+        expect(@user.errors.full_messages).to include("メールアドレスの入力を確認してください")
+      end
+      it '一意性制約に反すると登録できない' do
+        @user.save
+        another_user = FactoryBot.build(:user)
+        another_user.email = @user.email
+        another_user.valid?
+        expect(another_user.errors.full_messages).to include("メールアドレスはすでに存在します")
+      end
     end
-    it 'emailに「@」がないと登録できない' do
-      @user.email = 'sample_sample.com'
-      @user.valid?
-      expect(@user.errors.full_messages).to include('Email is invalid')
+    context 'passwordが登録できないとき' do
+      it 'passwordが空だと登録できない' do
+        @user.password = ''
+        @user.valid?
+        expect(@user.errors.full_messages).to include("パスワードを入力してください")
+      end
+      it 'passwordが5文字以下だと登録できない' do
+        @user.password = Faker::Alphanumeric.alphanumeric(number: 5, min_alpha: 1, min_numeric: 1)
+        @user.password_confirmation = @user.password
+        @user.valid?
+        expect(@user.errors.full_messages).to include("パスワードは6文字以上で入力してください")
+      end
+      it 'passwordが半角アルファベットのみだと登録できない' do
+        @user.password = Faker::Alphanumeric.alpha(number: 6)
+        @user.password_confirmation = @user.password
+        @user.valid?
+        expect(@user.errors.full_messages).to include("パスワードの入力を確認してください")
+      end
+      it 'passwordが半角数字のみだと登録できない' do
+        @user.password = Faker::Number.number(digits: 6)
+        @user.password_confirmation = @user.password
+        @user.valid?
+        expect(@user.errors.full_messages).to include("パスワードの入力を確認してください")
+      end
+      it 'password_confirmationが空だと登録できない' do
+        @user.password_confirmation = ''
+        @user.valid?
+        expect(@user.errors.full_messages).to include("パスワード（確認）とパスワードの入力が一致しません")
+      end
+      it 'password_confirmationがpasswordと一致していないと登録できない' do
+        @user.password = "#{@user.password}hoge"
+        @user.password_confirmation = "#{@user.password}fuga"
+        @user.valid?
+        expect(@user.errors.full_messages).to include("パスワード（確認）とパスワードの入力が一致しません")
+      end
     end
-    it '同じemailが既にDB上にあるとき登録できない' do
-      @user.save
-      another_user = FactoryBot.build(:user)
-      another_user.email = @user.email
-      another_user.valid?
-      expect(another_user.errors.full_messages).to include('Email has already been taken')
+    context '名前が登録できないとき' do
+      # 名前
+      it 'given_nameが空だと登録できない' do
+        @user.given_name = ''
+        @user.valid?
+        expect(@user.errors.full_messages).to include("名前(全角)を入力してください")
+      end
+      it 'given_nameに半角数字が混ざると登録できない' do
+        @user.given_name = "#{@user.given_name}0"
+        @user.valid?
+        expect(@user.errors.full_messages).to include("名前(全角)の入力を確認してください")
+      end
+      it 'given_nameに半角アルファベットが混ざると登録できない' do
+        @user.given_name = "#{@user.given_name}a"
+        @user.valid?
+        expect(@user.errors.full_messages).to include("名前(全角)の入力を確認してください")
+      end
+      it 'given_nameに半角記号文字が混ざると登録できない' do
+        @user.given_name = "#{@user.given_name}@"
+        @user.valid?
+        expect(@user.errors.full_messages).to include("名前(全角)の入力を確認してください")
+      end
+      # 苗字
+      it 'family_nameが空だと登録できない' do
+        @user.family_name = ''
+        @user.valid?
+        expect(@user.errors.full_messages).to include("苗字(全角)を入力してください")
+      end
+      it 'family_nameに半角数字が混ざると登録できない' do
+        @user.family_name = "#{@user.family_name}0"
+        @user.valid?
+        expect(@user.errors.full_messages).to include("苗字(全角)の入力を確認してください")
+      end
+      it 'family_nameに半角アルファベットが混ざると登録できない' do
+        @user.family_name = "#{@user.family_name}a"
+        @user.valid?
+        expect(@user.errors.full_messages).to include("苗字(全角)の入力を確認してください")
+      end
+      it 'family_nameに半角記号文字が混ざると登録できない' do
+        @user.family_name = "#{@user.family_name}@"
+        @user.valid?
+        expect(@user.errors.full_messages).to include("苗字(全角)の入力を確認してください")
+      end
     end
-    # password
-    it 'passwordが空だと登録できない' do
-      @user.password = ''
-      @user.valid?
-      expect(@user.errors.full_messages).to include("Password can't be blank")
+    context '名前(カナ)が登録できないとき' do
+      # 名前(カナ)
+      it 'given_name_kanaが空だと登録できない' do
+        @user.given_name_kana = ''
+        @user.valid?
+        expect(@user.errors.full_messages).to include("名前(カナ)を入力してください")
+      end
+      it 'given_name_kanaに半角数字が混ざると登録できない' do
+        @user.given_name_kana = "#{@user.given_name_kana}0"
+        @user.valid?
+        expect(@user.errors.full_messages).to include("名前(カナ)の入力を確認してください")
+      end
+      it 'given_name_kanaに半角アルファベットが混ざると登録できない' do
+        @user.given_name_kana = "#{@user.given_name_kana}a"
+        @user.valid?
+        expect(@user.errors.full_messages).to include("名前(カナ)の入力を確認してください")
+      end
+      it 'given_name_kanaに半角記号文字が混ざると登録できない' do
+        @user.given_name_kana = "#{@user.given_name_kana}@"
+        @user.valid?
+        expect(@user.errors.full_messages).to include("名前(カナ)の入力を確認してください")
+      end
+      it 'given_name_kanaにひらがなが混ざると登録できない' do
+        @user.given_name_kana = "#{@user.given_name_kana}あ"
+        @user.valid?
+        expect(@user.errors.full_messages).to include("名前(カナ)の入力を確認してください")
+      end
+      it 'given_name_kanaに漢字が混ざると登録できない' do
+        @user.given_name_kana = "#{@user.given_name_kana}漢"
+        @user.valid?
+        expect(@user.errors.full_messages).to include("名前(カナ)の入力を確認してください")
+      end
+      # 苗字(カナ)
+      it 'family_name_kanaが空だと登録できない' do
+        @user.family_name_kana = ''
+        @user.valid?
+        expect(@user.errors.full_messages).to include("苗字(カナ)を入力してください")
+      end
+      it 'family_name_kanaに半角数字が混ざると登録できない' do
+        @user.family_name_kana = "#{@user.family_name_kana}0"
+        @user.valid?
+        expect(@user.errors.full_messages).to include("苗字(カナ)の入力を確認してください")
+      end
+      it 'family_name_kanaに半角アルファベットが混ざると登録できない' do
+        @user.family_name_kana = "#{@user.family_name_kana}a"
+        @user.valid?
+        expect(@user.errors.full_messages).to include("苗字(カナ)の入力を確認してください")
+      end
+      it 'family_name_kanaに半角記号文字が混ざると登録できない' do
+        @user.family_name_kana = "#{@user.family_name_kana}@"
+        @user.valid?
+        expect(@user.errors.full_messages).to include("苗字(カナ)の入力を確認してください")
+      end
+      it 'family_name_kanaにひらがなが混ざると登録できない' do
+        @user.family_name_kana = "#{@user.family_name_kana}あ"
+        @user.valid?
+        expect(@user.errors.full_messages).to include("苗字(カナ)の入力を確認してください")
+      end
+      it 'family_name_kanaに漢字が混ざると登録できない' do
+        @user.family_name_kana = "#{@user.family_name_kana}漢"
+        @user.valid?
+        expect(@user.errors.full_messages).to include("苗字(カナ)の入力を確認してください")
+      end
     end
-    it 'passwordが6文字以下だと登録できない' do
-      @user.password = 'a0a0a'
-      @user.password_confirmation = @user.password
-      @user.valid?
-      expect(@user.errors.full_messages).to include('Password is too short (minimum is 6 characters)')
+    context '生年月日が登録できないとき' do
+      it '空だと登録できない' do
+        @user.birth_day = ''
+        @user.valid?
+        expect(@user.errors.full_messages).to include("生年月日を入力してください")
+      end
     end
-    it 'passwordが半角アルファベットのみだと登録できない' do
-      @user.password = 'aaaaaa'
-      @user.password_confirmation = @user.password
-      @user.valid?
-      expect(@user.errors.full_messages).to include('Password is invalid')
-    end
-    it 'passwordが半角数字のみだと登録できない' do
-      @user.password = '000000'
-      @user.password_confirmation = @user.password
-      @user.valid?
-      expect(@user.errors.full_messages).to include('Password is invalid')
-    end
-    it 'password_confirmationが空だと登録できない' do
-      @user.password_confirmation = ''
-      @user.valid?
-      expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")
-    end
-    it 'password_confirmationがpasswordと一致していないと登録できない' do
-      @user.password = "#{@user.password}hoge"
-      @user.password_confirmation = "#{@user.password}fuga"
-      @user.valid?
-      expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")
-    end
-    # given_name
-    it 'given_nameが空だと登録できない' do
-      @user.given_name = ''
-      @user.valid?
-      expect(@user.errors.full_messages).to include("Given name can't be blank")
-    end
-    it 'given_nameに半角数字が混ざると登録できない' do
-      @user.given_name = "#{@user.given_name}0"
-      @user.valid?
-      expect(@user.errors.full_messages).to include('Given name is invalid')
-    end
-    it 'given_nameに半角アルファベットが混ざると登録できない' do
-      @user.given_name = "#{@user.given_name}a"
-      @user.valid?
-      expect(@user.errors.full_messages).to include('Given name is invalid')
-    end
-    it 'given_nameに半角記号文字が混ざると登録できない' do
-      @user.given_name = "#{@user.given_name}@"
-      @user.valid?
-      expect(@user.errors.full_messages).to include('Given name is invalid')
-    end
-    # family_name
-    it 'family_nameが空だと登録できない' do
-      @user.family_name = ''
-      @user.valid?
-      expect(@user.errors.full_messages).to include("Family name can't be blank")
-    end
-    it 'family_nameに半角数字が混ざると登録できない' do
-      @user.family_name = "#{@user.family_name}0"
-      @user.valid?
-      expect(@user.errors.full_messages).to include('Family name is invalid')
-    end
-    it 'family_nameに半角アルファベットが混ざると登録できない' do
-      @user.family_name = "#{@user.family_name}a"
-      @user.valid?
-      expect(@user.errors.full_messages).to include('Family name is invalid')
-    end
-    it 'family_nameに半角記号文字が混ざると登録できない' do
-      @user.family_name = "#{@user.family_name}@"
-      @user.valid?
-      expect(@user.errors.full_messages).to include('Family name is invalid')
-    end
-    # given_name_kana
-    it 'given_name_kanaが空だと登録できない' do
-      @user.given_name_kana = ''
-      @user.valid?
-      expect(@user.errors.full_messages).to include("Given name kana can't be blank")
-    end
-    it 'given_name_kanaに半角数字が混ざると登録できない' do
-      @user.given_name_kana = "#{@user.given_name_kana}0"
-      @user.valid?
-      expect(@user.errors.full_messages).to include('Given name kana is invalid')
-    end
-    it 'given_name_kanaに半角アルファベットが混ざると登録できない' do
-      @user.given_name_kana = "#{@user.given_name_kana}a"
-      @user.valid?
-      expect(@user.errors.full_messages).to include('Given name kana is invalid')
-    end
-    it 'given_name_kanaに半角記号文字が混ざると登録できない' do
-      @user.given_name_kana = "#{@user.given_name_kana}@"
-      @user.valid?
-      expect(@user.errors.full_messages).to include('Given name kana is invalid')
-    end
-    it 'given_name_kanaにひらがなが混ざると登録できない' do
-      @user.given_name_kana = "#{@user.given_name_kana}あ"
-      @user.valid?
-      expect(@user.errors.full_messages).to include('Given name kana is invalid')
-    end
-    it 'given_name_kanaに漢字が混ざると登録できない' do
-      @user.given_name_kana = "#{@user.given_name_kana}漢"
-      @user.valid?
-      expect(@user.errors.full_messages).to include('Given name kana is invalid')
-    end
-    # family_name_kana
-    it 'family_name_kanaが空だと登録できない' do
-      @user.family_name_kana = ''
-      @user.valid?
-      expect(@user.errors.full_messages).to include("Family name kana can't be blank")
-    end
-    it 'family_name_kanaに半角数字が混ざると登録できない' do
-      @user.family_name_kana = "#{@user.family_name_kana}0"
-      @user.valid?
-      expect(@user.errors.full_messages).to include('Family name kana is invalid')
-    end
-    it 'family_name_kanaに半角アルファベットが混ざると登録できない' do
-      @user.family_name_kana = "#{@user.family_name_kana}a"
-      @user.valid?
-      expect(@user.errors.full_messages).to include('Family name kana is invalid')
-    end
-    it 'family_name_kanaに半角記号文字が混ざると登録できない' do
-      @user.family_name_kana = "#{@user.family_name_kana}@"
-      @user.valid?
-      expect(@user.errors.full_messages).to include('Family name kana is invalid')
-    end
-    it 'family_name_kanaにひらがなが混ざると登録できない' do
-      @user.family_name_kana = "#{@user.family_name_kana}あ"
-      @user.valid?
-      expect(@user.errors.full_messages).to include('Family name kana is invalid')
-    end
-    it 'family_name_kanaに漢字が混ざると登録できない' do
-      @user.family_name_kana = "#{@user.family_name_kana}漢"
-      @user.valid?
-      expect(@user.errors.full_messages).to include('Family name kana is invalid')
-    end
-    # birth_day
-    it 'birth_dayが空だと登録できない' do
-      @user.birth_day = ''
-      @user.valid?
-      expect(@user.errors.full_messages).to include("Birth day can't be blank")
-    end
-    # 正常
-    it '条件に合う入力を行っていれば登録できる' do
-      expect(@user).to be_valid
-      users = FactoryBot.create_list(:user, 30)
-      users.each do |user|
-        if !(expect(user).to be_valid)
-          puts user
-        end
+    context '登録できるとき' do
+      it '条件に合う入力を行っていれば登録できる' do
+        expect(@user).to be_valid
+        users = FactoryBot.create_list(:user, 30)
+        users.each { |user| expect(user).to be_valid }
       end
     end
   end


### PR DESCRIPTION
# what
入力フォームへの入力を間違えた際のエラーメッセージを日本語化する

# why
ユーザに入力フォームのミスを分かりやすく伝えるため